### PR TITLE
Updated shortcut for Mac platform.

### DIFF
--- a/main.js
+++ b/main.js
@@ -29,6 +29,6 @@ define(function (require, exports, module) {
     // The label of the menu item is the name we gave the command (see above)
     var menu = Menus.getMenu(Menus.AppMenuBar.EDIT_MENU);
     menu.addMenuItem(COMMAND_ID, [{key: "Ctrl-Shift-I", platform: "win"},
-                                  {key: "Ctrl-Shift-I", platform: "mac"}]);
+                                  {key: "Cmd-Shift-I", platform: "mac"}]);
     
 });


### PR DESCRIPTION
Replaced shortcut for mac platform from Ctrl-Shift-I to Cmd-Shift-I.
